### PR TITLE
Add ttk widget groups, richer dialog blocks, and shared GUI prefill helper

### DIFF
--- a/blockly_setup_end.js
+++ b/blockly_setup_end.js
@@ -141,6 +141,14 @@ toolboxString += '<category name="Entry" colour="#555555" custom="GUI_Entries">'
 toolboxString += '</category>';
 toolboxString += '<category name="Dialog" colour="#555555" custom="GUI_Dialog">';
 toolboxString += '</category>';
+toolboxString += '<category name="Checkbutton" colour="#555555" custom="GUI_Checkbuttons">';
+toolboxString += '</category>';
+toolboxString += '<category name="Radiobutton" colour="#555555" custom="GUI_Radiobuttons">';
+toolboxString += '</category>';
+toolboxString += '<category name="Combobox" colour="#555555" custom="GUI_Comboboxes">';
+toolboxString += '</category>';
+toolboxString += '<category name="Progressbar" colour="#555555" custom="GUI_Progressbars">';
+toolboxString += '</category>';
 toolboxString += '</category>';
 toolboxString += '<category colour="90" name="EV3">'; 
 toolboxString += '<category colour="90" name="Brick">';   
@@ -310,6 +318,7 @@ workspace.registerToolboxCategoryCallback('GUI_Buttons', function(workspace){
                                                                                     
 
                                                                                     xmlList.push(Blockly.Xml.textToDom('<block type="tkinter_set_button_command"></block>'));
+                                                                                    xmlList.push(Blockly.Xml.textToDom('<block type="tkinter_button_set_enabled"></block>'));
                                                                                     return xmlList;
                                                                                    }
                                          );
@@ -342,10 +351,112 @@ workspace.registerToolboxCategoryCallback('GUI_Entries', function(workspace){
 
 workspace.registerToolboxCategoryCallback('GUI_Dialog', function(workspace){
                                                                                     var xmlList = [];
-                                                                                    xmlList.push(Blockly.Xml.textToDom('<block type="tkinter_messagebox"><value name="TEXT"><shadow type="text"><field name="TEXT">Hello</field></shadow></value></block>'));
+                                                                                    xmlList.push(Blockly.Xml.textToDom('<block type="tkinter_messagebox"><value name="TITLE"><shadow type="text"><field name="TEXT">Message Box</field></shadow></value><value name="TEXT"><shadow type="text"><field name="TEXT">Hello</field></shadow></value></block>'));
+                                                                                    xmlList.push(Blockly.Xml.textToDom('<block type="tkinter_ask_dialog"><value name="TITLE"><shadow type="text"><field name="TEXT">Question</field></shadow></value><value name="TEXT"><shadow type="text"><field name="TEXT">Do you want to continue?</field></shadow></value></block>'));
+                                                                                    xmlList.push(Blockly.Xml.textToDom('<block type="tkinter_simpledialog"><value name="TITLE"><shadow type="text"><field name="TEXT">Input</field></shadow></value><value name="PROMPT"><shadow type="text"><field name="TEXT">What is your name?</field></shadow></value></block>'));
+                                                                                    xmlList.push(Blockly.Xml.textToDom('<block type="tkinter_filedialog"><value name="TITLE"><shadow type="text"><field name="TEXT">Select a file</field></shadow></value></block>'));
+                                                                                    xmlList.push(Blockly.Xml.textToDom('<block type="tkinter_colorchooser"><value name="TITLE"><shadow type="text"><field name="TEXT">Choose a colour</field></shadow></value></block>'));
                                                                                     return xmlList;
                                                                                    }
                                          );
+
+workspace.registerToolboxCategoryCallback('GUI_Checkbuttons', function(workspace){
+                                                                                    var xmlList = [];
+                                                                                    xmlList.push(Blockly.Xml.textToDom('<button text="Create checkbutton..." callbackKey="createGUICheckbuttonButtonPressed"></button>'));
+                                                                                    var variableModelList = workspace.getVariablesOfType('GUI_Checkbutton');
+                                                                                    if(variableModelList.length>0){
+                                                                                      for (var i = 0, variable; (variable = variableModelList[i]); i++) {
+                                                                                        var block = Blockly.utils.xml.createElement('block');
+                                                                                        block.setAttribute('type', 'tkinter_variables_get_checkbutton');
+                                                                                        block.setAttribute('gap', 8);
+                                                                                        block.appendChild(Blockly.Variables.generateVariableFieldDom(variable));
+                                                                                        xmlList.push(block);
+                                                                                      }
+                                                                                    }
+                                                                                    xmlList.push(Blockly.Xml.textToDom('<block type="tkinter_add_widget_to_window"></block>'));
+                                                                                    xmlList.push(Blockly.Xml.textToDom('<block type="tkinter_set_widget_text"><value name="TEXT"><shadow type="text"><field name="TEXT">I agree</field></shadow></value></block>'));
+                                                                                    return xmlList;
+                                                                                   }
+                                         );
+
+workspace.registerToolboxCategoryCallback('GUI_Radiobuttons', function(workspace){
+                                                                                    var xmlList = [];
+                                                                                    xmlList.push(Blockly.Xml.textToDom('<button text="Create radiobutton..." callbackKey="createGUIRadiobuttonButtonPressed"></button>'));
+                                                                                    var variableModelList = workspace.getVariablesOfType('GUI_Radiobutton');
+                                                                                    if(variableModelList.length>0){
+                                                                                      for (var i = 0, variable; (variable = variableModelList[i]); i++) {
+                                                                                        var block = Blockly.utils.xml.createElement('block');
+                                                                                        block.setAttribute('type', 'tkinter_variables_get_radiobutton');
+                                                                                        block.setAttribute('gap', 8);
+                                                                                        block.appendChild(Blockly.Variables.generateVariableFieldDom(variable));
+                                                                                        xmlList.push(block);
+                                                                                      }
+                                                                                    }
+                                                                                    xmlList.push(Blockly.Xml.textToDom('<block type="tkinter_add_widget_to_window"></block>'));
+                                                                                    xmlList.push(Blockly.Xml.textToDom('<block type="tkinter_set_widget_text"><value name="TEXT"><shadow type="text"><field name="TEXT">Option A</field></shadow></value></block>'));
+                                                                                    return xmlList;
+                                                                                   }
+                                         );
+
+workspace.registerToolboxCategoryCallback('GUI_Comboboxes', function(workspace){
+                                                                                    var xmlList = [];
+                                                                                    xmlList.push(Blockly.Xml.textToDom('<button text="Create combobox..." callbackKey="createGUIComboboxButtonPressed"></button>'));
+                                                                                    var variableModelList = workspace.getVariablesOfType('GUI_Combobox');
+                                                                                    if(variableModelList.length>0){
+                                                                                      for (var i = 0, variable; (variable = variableModelList[i]); i++) {
+                                                                                        var block = Blockly.utils.xml.createElement('block');
+                                                                                        block.setAttribute('type', 'tkinter_variables_get_combobox');
+                                                                                        block.setAttribute('gap', 8);
+                                                                                        block.appendChild(Blockly.Variables.generateVariableFieldDom(variable));
+                                                                                        xmlList.push(block);
+                                                                                      }
+                                                                                    }
+                                                                                    xmlList.push(Blockly.Xml.textToDom('<block type="tkinter_add_widget_to_window"></block>'));
+                                                                                    xmlList.push(Blockly.Xml.textToDom('<block type="tkinter_combobox_set_values"><value name="VALUES"><shadow type="lists_create_with"><mutation items="3"></mutation></shadow></value></block>'));
+                                                                                    xmlList.push(Blockly.Xml.textToDom('<block type="tkinter_combobox_get_text"></block>'));
+                                                                                    return xmlList;
+                                                                                   }
+                                         );
+
+workspace.registerToolboxCategoryCallback('GUI_Progressbars', function(workspace){
+                                                                                    var xmlList = [];
+                                                                                    xmlList.push(Blockly.Xml.textToDom('<button text="Create progressbar..." callbackKey="createGUIProgressbarButtonPressed"></button>'));
+                                                                                    var variableModelList = workspace.getVariablesOfType('GUI_Progressbar');
+                                                                                    if(variableModelList.length>0){
+                                                                                      for (var i = 0, variable; (variable = variableModelList[i]); i++) {
+                                                                                        var block = Blockly.utils.xml.createElement('block');
+                                                                                        block.setAttribute('type', 'tkinter_variables_get_progressbar');
+                                                                                        block.setAttribute('gap', 8);
+                                                                                        block.appendChild(Blockly.Variables.generateVariableFieldDom(variable));
+                                                                                        xmlList.push(block);
+                                                                                      }
+                                                                                    }
+                                                                                    xmlList.push(Blockly.Xml.textToDom('<block type="tkinter_add_widget_to_window"></block>'));
+                                                                                    xmlList.push(Blockly.Xml.textToDom('<block type="tkinter_progressbar_set_value"><value name="VALUE"><shadow type="math_number"><field name="NUM">50</field></shadow></value></block>'));
+                                                                                    xmlList.push(Blockly.Xml.textToDom('<block type="tkinter_progressbar_start_stop"></block>'));
+                                                                                    return xmlList;
+                                                                                   }
+                                         );
+
+workspace.registerButtonCallback('createGUICheckbuttonButtonPressed', function(button){
+                                                                           Blockly.Variables.createVariableButtonHandler(button.getTargetWorkspace(), null, 'GUI_Checkbutton');
+                                                                          }
+                                );
+
+workspace.registerButtonCallback('createGUIRadiobuttonButtonPressed', function(button){
+                                                                           Blockly.Variables.createVariableButtonHandler(button.getTargetWorkspace(), null, 'GUI_Radiobutton');
+                                                                          }
+                                );
+
+workspace.registerButtonCallback('createGUIComboboxButtonPressed', function(button){
+                                                                           Blockly.Variables.createVariableButtonHandler(button.getTargetWorkspace(), null, 'GUI_Combobox');
+                                                                          }
+                                );
+
+workspace.registerButtonCallback('createGUIProgressbarButtonPressed', function(button){
+                                                                           Blockly.Variables.createVariableButtonHandler(button.getTargetWorkspace(), null, 'GUI_Progressbar');
+                                                                          }
+                                );
 
 workspace.registerButtonCallback('createGUIEntryButtonPressed', function(button){
                                                                            Blockly.Variables.createVariableButtonHandler(button.getTargetWorkspace(), null, 'GUI_Entry');

--- a/blocks/gui.js
+++ b/blocks/gui.js
@@ -99,6 +99,78 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "helpUrl": ""
   },
   {
+    "type": "tkinter_variables_get_checkbutton",
+    "message0": "%1",
+    "args0": [
+      {
+        "type": "field_variable",
+        "name": "VAR",
+        "variable": "%{BKY_VARIABLES_DEFAULT_NAME}",
+        "variableTypes": ["GUI_Checkbutton"],
+        "defaultType": "GUI_Checkbutton"
+      }
+    ],
+    "output": "GUI_Checkbutton",
+    "inputsInline": true,
+    "colour": "#555555",
+    "tooltip": "Get the checkbutton variable",
+    "helpUrl": ""
+  },
+  {
+    "type": "tkinter_variables_get_radiobutton",
+    "message0": "%1",
+    "args0": [
+      {
+        "type": "field_variable",
+        "name": "VAR",
+        "variable": "%{BKY_VARIABLES_DEFAULT_NAME}",
+        "variableTypes": ["GUI_Radiobutton"],
+        "defaultType": "GUI_Radiobutton"
+      }
+    ],
+    "output": "GUI_Radiobutton",
+    "inputsInline": true,
+    "colour": "#555555",
+    "tooltip": "Get the radiobutton variable",
+    "helpUrl": ""
+  },
+  {
+    "type": "tkinter_variables_get_combobox",
+    "message0": "%1",
+    "args0": [
+      {
+        "type": "field_variable",
+        "name": "VAR",
+        "variable": "%{BKY_VARIABLES_DEFAULT_NAME}",
+        "variableTypes": ["GUI_Combobox"],
+        "defaultType": "GUI_Combobox"
+      }
+    ],
+    "output": "GUI_Combobox",
+    "inputsInline": true,
+    "colour": "#555555",
+    "tooltip": "Get the combobox variable",
+    "helpUrl": ""
+  },
+  {
+    "type": "tkinter_variables_get_progressbar",
+    "message0": "%1",
+    "args0": [
+      {
+        "type": "field_variable",
+        "name": "VAR",
+        "variable": "%{BKY_VARIABLES_DEFAULT_NAME}",
+        "variableTypes": ["GUI_Progressbar"],
+        "defaultType": "GUI_Progressbar"
+      }
+    ],
+    "output": "GUI_Progressbar",
+    "inputsInline": true,
+    "colour": "#555555",
+    "tooltip": "Get the progressbar variable",
+    "helpUrl": ""
+  },
+  {
     "type": "tkinter_set_window_as_root",
     "message0": "set %1 to main window",
     "args0": [
@@ -201,7 +273,7 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
   ,
   {
     "type": "tkinter_messagebox",
-    "message0": "make a %1 box appear with message %2",
+    "message0": "make a %1 box appear with title %2 and message %3",
     "args0": [
       {
         "type": "field_dropdown",
@@ -214,6 +286,11 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
       },
       {
         "type": "input_value",
+        "name": "TITLE",
+        "check": "String"
+      },
+      {
+        "type": "input_value",
         "name": "TEXT",
         "check": "String"
       }
@@ -222,6 +299,38 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "nextStatement": null,
     "colour": "#555555",
     "tooltip": "Show a messagebox (info, warning or error) with the given text",
+    "helpUrl": ""
+  },
+  {
+    "type": "tkinter_ask_dialog",
+    "message0": "ask with %1 title %2 and message %3",
+    "args0": [
+      {
+        "type": "field_dropdown",
+        "name": "MODE",
+        "options": [
+          ["yes/no", "ASK_YES_NO"],
+          ["ok/cancel", "ASK_OK_CANCEL"],
+          ["retry/cancel", "ASK_RETRY_CANCEL"],
+          ["yes/no/cancel", "ASK_YES_NO_CANCEL"],
+          ["question", "ASK_QUESTION"]
+        ]
+      },
+      {
+        "type": "input_value",
+        "name": "TITLE",
+        "check": "String"
+      },
+      {
+        "type": "input_value",
+        "name": "TEXT",
+        "check": "String"
+      }
+    ],
+    "output": null,
+    "inputsInline": true,
+    "colour": "#555555",
+    "tooltip": "Show a question dialog and return the user's choice",
     "helpUrl": ""
   }
 
@@ -264,6 +373,160 @@ Blockly.defineBlocksWithJsonArray([  // BEGIN JSON EXTRACT
     "colour": "#555555",
     "tooltip": "Delete from index 0 to tkinter.END for the Entry widget",
     "helpUrl": ""
+  },
+  {
+    "type": "tkinter_combobox_set_values",
+    "message0": "set choices in %1 to %2",
+    "args0": [
+      {
+        "type": "input_value",
+        "name": "COMBOBOX",
+        "check": "GUI_Combobox"
+      },
+      {
+        "type": "input_value",
+        "name": "VALUES"
+      }
+    ],
+    "inputsInline": true,
+    "previousStatement": null,
+    "nextStatement": null,
+    "colour": "#555555",
+    "tooltip": "Set the options available in a Combobox",
+    "helpUrl": ""
+  },
+  {
+    "type": "tkinter_combobox_get_text",
+    "message0": "the selected text in %1",
+    "args0": [
+      {
+        "type": "input_value",
+        "name": "COMBOBOX",
+        "check": "GUI_Combobox"
+      }
+    ],
+    "output": "String",
+    "inputsInline": true,
+    "colour": "#555555",
+    "tooltip": "Get the currently selected text from the Combobox",
+    "helpUrl": ""
+  },
+  {
+    "type": "tkinter_progressbar_set_value",
+    "message0": "set progress of %1 to %2",
+    "args0": [
+      {
+        "type": "input_value",
+        "name": "PROGRESSBAR",
+        "check": "GUI_Progressbar"
+      },
+      {
+        "type": "input_value",
+        "name": "VALUE",
+        "check": "Number"
+      }
+    ],
+    "inputsInline": true,
+    "previousStatement": null,
+    "nextStatement": null,
+    "colour": "#555555",
+    "tooltip": "Set the current value of the Progressbar",
+    "helpUrl": ""
+  },
+  {
+    "type": "tkinter_progressbar_start_stop",
+    "message0": "%1 indeterminate animation for %2",
+    "args0": [
+      {
+        "type": "field_dropdown",
+        "name": "MODE",
+        "options": [
+          ["start", "START"],
+          ["stop", "STOP"]
+        ]
+      },
+      {
+        "type": "input_value",
+        "name": "PROGRESSBAR",
+        "check": "GUI_Progressbar"
+      }
+    ],
+    "inputsInline": true,
+    "previousStatement": null,
+    "nextStatement": null,
+    "colour": "#555555",
+    "tooltip": "Start or stop the indeterminate animation",
+    "helpUrl": ""
+  },
+  {
+    "type": "tkinter_simpledialog",
+    "message0": "ask for %1 with title %2 and prompt %3",
+    "args0": [
+      {
+        "type": "field_dropdown",
+        "name": "MODE",
+        "options": [
+          ["text", "STRING"],
+          ["whole number", "INTEGER"],
+          ["decimal number", "FLOAT"]
+        ]
+      },
+      {
+        "type": "input_value",
+        "name": "TITLE",
+        "check": "String"
+      },
+      {
+        "type": "input_value",
+        "name": "PROMPT",
+        "check": "String"
+      }
+    ],
+    "output": null,
+    "inputsInline": true,
+    "colour": "#555555",
+    "tooltip": "Show a simple input dialog and return what the user entered",
+    "helpUrl": ""
+  },
+  {
+    "type": "tkinter_filedialog",
+    "message0": "ask for a file path to %1 with title %2",
+    "args0": [
+      {
+        "type": "field_dropdown",
+        "name": "MODE",
+        "options": [
+          ["open", "OPEN"],
+          ["save", "SAVE"]
+        ]
+      },
+      {
+        "type": "input_value",
+        "name": "TITLE",
+        "check": "String"
+      }
+    ],
+    "output": "String",
+    "inputsInline": true,
+    "colour": "#555555",
+    "tooltip": "Show a file-open or file-save dialog and return the chosen path",
+    "helpUrl": ""
+  },
+  {
+    "type": "tkinter_colorchooser",
+    "message0": "ask for a colour with title %1",
+    "args0": [
+      {
+        "type": "input_value",
+        "name": "TITLE",
+        "check": "String"
+      }
+    ],
+    "output": "String",
+    "inputsInline": true,
+    "colour": "#555555",
+    "tooltip": "Show a colour picker dialog and return a hex colour string",
+    "helpUrl": ""
   }
 
  ]);  // END JSON EXTRACT (Do not delete this comment.)
@@ -274,7 +537,7 @@ Blockly.Blocks['tkinter_add_widget_to_window'] = {
     // Header
     this.appendDummyInput()
         .appendField("Add");
-    this.appendValueInput("WIDGET").setCheck(["GUI_Label","GUI_Button","GUI_Entry"]);
+    this.appendValueInput("WIDGET").setCheck(["GUI_Label","GUI_Button","GUI_Entry","GUI_Checkbutton","GUI_Radiobutton","GUI_Combobox","GUI_Progressbar"]);
     this.appendDummyInput().appendField("to window");
     this.appendValueInput("WINDOW").setCheck("GUI_Window");
 
@@ -297,7 +560,7 @@ Blockly.Blocks['tkinter_add_widget_to_window'] = {
     this.setPreviousStatement(true, null);
     this.setNextStatement(true, null);
     this.setColour("#555555");
-    this.setTooltip("Create ttk.Label, run configuration statements, then apply a layout manager.");
+    this.setTooltip("Create a ttk widget, run configuration statements, then apply a layout manager.");
     this.setHelpUrl("");
 
     this.updateShape_();
@@ -372,11 +635,66 @@ Blockly.Blocks['tkinter_add_widget_to_window'] = {
 };
 // --- END: tkinter_add_widget_to_window (block definition)
 
+// --- BEGIN: shared tkinter prefill helpers
+function tkinterPrefillValueInputFromParent(block, inputName, getterTypeByVariableType) {
+  if (!block.workspace || block.isInFlyout) return;
+  if (block._tkinterPrefilled) return;
+
+  const input = block.getInput(inputName);
+  if (!input || input.connection.targetBlock()) return;
+
+  const parent = block.getSurroundParent();
+  if (!parent || parent.type !== 'tkinter_add_widget_to_window') return;
+
+  const parentWidgetBlock = parent.getInputTargetBlock('WIDGET');
+  if (!parentWidgetBlock) return;
+
+  let newGetter = null;
+  const varField = parentWidgetBlock.getField('VAR');
+  if (varField && typeof varField.getVariable === 'function') {
+    const model = varField.getVariable();
+    if (model) {
+      const varId = model.getId();
+      const getterType = getterTypeByVariableType[model.type];
+      if (varId && getterType) {
+        newGetter = block.workspace.newBlock(getterType);
+        newGetter.setFieldValue(varId, 'VAR');
+      } else {
+        const xml = Blockly.Xml.blockToDom(parentWidgetBlock, true);
+        newGetter = Blockly.Xml.domToBlock(xml, block.workspace);
+      }
+    }
+  }
+
+  if (newGetter) {
+    newGetter.initSvg && newGetter.initSvg();
+    newGetter.render && newGetter.render();
+    input.connection.connect(newGetter.outputConnection);
+    block._tkinterPrefilled = true;
+  }
+}
+
+function tkinterOnChangePrefillFromParent(block, e, prefillFn) {
+  if (!block.workspace || block.isInFlyout || !e) return;
+
+  const typesToWatch = new Set([
+    Blockly.Events.BLOCK_CREATE,
+    Blockly.Events.BLOCK_MOVE,
+    Blockly.Events.CHANGE
+  ]);
+  if (!typesToWatch.has(e.type)) return;
+
+  setTimeout(function() {
+    try { prefillFn(); } catch (err) { /* no-op */ }
+  }, 0);
+}
+// --- END: shared tkinter prefill helpers
+
 // --- BEGIN: tkinter_set_widget_text (block definition)
 Blockly.Blocks['tkinter_set_widget_text'] = {
   init: function() {
     this.appendDummyInput().appendField("Set");
-    this.appendValueInput("WIDGET").setCheck(["GUI_Label","GUI_Button"]);
+    this.appendValueInput("WIDGET").setCheck(["GUI_Label","GUI_Button","GUI_Checkbutton","GUI_Radiobutton"]);
     this.appendDummyInput().appendField("text to");
     this.appendValueInput("TEXT").setCheck("String");
 
@@ -387,77 +705,20 @@ Blockly.Blocks['tkinter_set_widget_text'] = {
     this.setHelpUrl("");
   },
 
-  /**
-   * Try to prefill WIDGET from the nearest surrounding parent
-   * 'tkinter_add_widget_to_window' if WIDGET is empty.
-   */
-  _prefillLabelFromParent_: function() {
-    if (!this.workspace || this.isInFlyout) return;
-    if (this._labelPrefilled) return; // guard: do once
-
-    const myLabelInput = this.getInput('WIDGET');
-    if (!myLabelInput || myLabelInput.connection.targetBlock()) return; // already filled
-
-    // Is this block inside our target parent?
-    const parent = this.getSurroundParent();
-    if (!parent || parent.type !== 'tkinter_add_widget_to_window') return;
-
-    // What is the parent's label value block?
-    const parentWidgetBlock = parent.getInputTargetBlock('WIDGET');
-    if (!parentWidgetBlock) return;
-
-    // If the parent carries a GUI_Label variable getter, copy its variable id.
-    // Your getter block type is 'tkinter_variables_get_label' with field 'VAR'.
-    let varId = null;
-    let newGetter = null;
-    const varField = parentWidgetBlock.getField('VAR');
-    if (varField && typeof varField.getVariable === 'function') {
-      const model = varField.getVariable();
-      if (model) {
-          varId = model.getId();
-        if (varId) {
-          // Create a *real* getter block bound to the same variable id.
-          if (model.type == "GUI_Label") newGetter = this.workspace.newBlock('tkinter_variables_get_label');
-          if (model.type == "GUI_Button") newGetter = this.workspace.newBlock('tkinter_variables_get_button');
-          newGetter.setFieldValue(varId, 'VAR');   // set by id to keep it robust
-        } else {
-          // Fallback: shallow-clone the parent's value block (covers rare cases).
-          const xml = Blockly.Xml.blockToDom(parentWidgetBlock, /*opt_noId*/ true);
-          newGetter = Blockly.Xml.domToBlock(xml, this.workspace);
-        }
-      }
-    }
-
-
-    // Render and connect into our WIDGET input.
-    if (newGetter) {
-      newGetter.initSvg && newGetter.initSvg();
-      newGetter.render && newGetter.render();
-      myLabelInput.connection.connect(newGetter.outputConnection);
-      this._labelPrefilled = true;
-    }
+  _prefillWidgetFromParent_: function() {
+    tkinterPrefillValueInputFromParent(this, 'WIDGET', {
+      'GUI_Label': 'tkinter_variables_get_label',
+      'GUI_Button': 'tkinter_variables_get_button',
+      'GUI_Checkbutton': 'tkinter_variables_get_checkbutton',
+      'GUI_Radiobutton': 'tkinter_variables_get_radiobutton'
+    });
   },
 
-  /**
-   * Listen for create/move/parent changes and prefill once.
-   */
   onchange: function(e) {
-    if (!this.workspace || this.isInFlyout || !e) return;
-
-    // Only react to events that affect parentage/placement of this block.
-    const typesToWatch = new Set([
-      Blockly.Events.BLOCK_CREATE,
-      Blockly.Events.BLOCK_MOVE,
-      Blockly.Events.CHANGE
-    ]);
-    if (!typesToWatch.has(e.type)) return;
-
-    // Small debounce: run after Blockly finishes any sync updates.
-    // This avoids running too early while connections are still changing.
     const self = this;
-    setTimeout(function() {
-      try { self._prefillLabelFromParent_(); } catch (err) { /* no-op */ }
-    }, 0);
+    tkinterOnChangePrefillFromParent(this, e, function() {
+      self._prefillWidgetFromParent_();
+    });
   }
 };
 
@@ -476,76 +737,49 @@ Blockly.Blocks['tkinter_set_button_command'] = {
     this.setHelpUrl("");
   },
 
-  /**
-   * Try to prefill BUTTON from the nearest surrounding parent
-   * 'tkinter_add_widget_to_window' if BUTTON is empty.
-   */
   _prefillButtonFromParent_: function() {
-    if (!this.workspace || this.isInFlyout) return;
-    if (this._labelPrefilled) return; // guard: do once
-
-    const myButtonInput = this.getInput('BUTTON');
-    if (!myButtonInput || myButtonInput.connection.targetBlock()) return; // already filled
-
-    // Is this block inside our target parent?
-    const parent = this.getSurroundParent();
-    if (!parent || parent.type !== 'tkinter_add_widget_to_window') return;
-
-    // What is the parent's label value block?
-    const parentWidgetBlock = parent.getInputTargetBlock('WIDGET');
-    if (!parentWidgetBlock) return;
-
-    // If the parent carries a GUI_Button variable getter, copy its variable id.
-    // Your getter block type is 'tkinter_variables_get_label' with field 'VAR'.
-    let varId = null;
-    let newGetter = null;
-    const varField = parentWidgetBlock.getField('VAR');
-    if (varField && typeof varField.getVariable === 'function') {
-      const model = varField.getVariable();
-      if (model) {
-          varId = model.getId();
-        if (varId) {
-          // Create a *real* getter block bound to the same variable id.
-          if (model.type == "GUI_Button") newGetter = this.workspace.newBlock('tkinter_variables_get_button');
-          if (model.type == "GUI_Entry") newGetter = this.workspace.newBlock('tkinter_variables_get_entry');
-          newGetter.setFieldValue(varId, 'VAR');   // set by id to keep it robust
-        } else {
-          // Fallback: shallow-clone the parent's value block (covers rare cases).
-          const xml = Blockly.Xml.blockToDom(parentWidgetBlock, /*opt_noId*/ true);
-          newGetter = Blockly.Xml.domToBlock(xml, this.workspace);
-        }
-      }
-    }
-
-
-    // Render and connect into our BUTTON input.
-    if (newGetter) {
-      newGetter.initSvg && newGetter.initSvg();
-      newGetter.render && newGetter.render();
-      myButtonInput.connection.connect(newGetter.outputConnection);
-      this._labelPrefilled = true;
-    }
+    tkinterPrefillValueInputFromParent(this, 'BUTTON', {
+      'GUI_Button': 'tkinter_variables_get_button'
+    });
   },
 
-  /**
-   * Listen for create/move/parent changes and prefill once.
-   */
   onchange: function(e) {
-    if (!this.workspace || this.isInFlyout || !e) return;
-
-    // Only react to events that affect parentage/placement of this block.
-    const typesToWatch = new Set([
-      Blockly.Events.BLOCK_CREATE,
-      Blockly.Events.BLOCK_MOVE,
-      Blockly.Events.CHANGE
-    ]);
-    if (!typesToWatch.has(e.type)) return;
-
-    // Small debounce: run after Blockly finishes any sync updates.
-    // This avoids running too early while connections are still changing.
     const self = this;
-    setTimeout(function() {
-      try { self._prefillButtonFromParent_(); } catch (err) { /* no-op */ }
-    }, 0);
+    tkinterOnChangePrefillFromParent(this, e, function() {
+      self._prefillButtonFromParent_();
+    });
+  }
+};
+
+// --- BEGIN: tkinter_button_set_enabled (block definition)
+Blockly.Blocks['tkinter_button_set_enabled'] = {
+  init: function() {
+    this.appendDummyInput().appendField("set");
+    this.appendValueInput("BUTTON").setCheck("GUI_Button");
+    this.appendDummyInput().appendField("to");
+    this.appendDummyInput().appendField(new Blockly.FieldDropdown([
+      ["enabled", "ENABLED"],
+      ["disabled", "DISABLED"]
+    ]), "STATE");
+
+    this.setInputsInline(true);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour("#555555");
+    this.setTooltip("Enable or disable the specified button.");
+    this.setHelpUrl("");
+  },
+
+  _prefillButtonFromParent_: function() {
+    tkinterPrefillValueInputFromParent(this, 'BUTTON', {
+      'GUI_Button': 'tkinter_variables_get_button'
+    });
+  },
+
+  onchange: function(e) {
+    const self = this;
+    tkinterOnChangePrefillFromParent(this, e, function() {
+      self._prefillButtonFromParent_();
+    });
   }
 };

--- a/generators/python/gui.js
+++ b/generators/python/gui.js
@@ -97,6 +97,30 @@ Blockly.Python['tkinter_variables_get_entry'] = function(block) {
   return [code, Blockly.Python.ORDER_ATOMIC];
 };
 
+Blockly.Python['tkinter_variables_get_checkbutton'] = function(block) {
+  Blockly.Python.definitions_['tkinter_imports'] = tkinter_imports;
+  var code = Blockly.Python.variableDB_.getName(block.getFieldValue('VAR'),Blockly.VARIABLE_CATEGORY_NAME);
+  return [code, Blockly.Python.ORDER_ATOMIC];
+};
+
+Blockly.Python['tkinter_variables_get_radiobutton'] = function(block) {
+  Blockly.Python.definitions_['tkinter_imports'] = tkinter_imports;
+  var code = Blockly.Python.variableDB_.getName(block.getFieldValue('VAR'),Blockly.VARIABLE_CATEGORY_NAME);
+  return [code, Blockly.Python.ORDER_ATOMIC];
+};
+
+Blockly.Python['tkinter_variables_get_combobox'] = function(block) {
+  Blockly.Python.definitions_['tkinter_imports'] = tkinter_imports;
+  var code = Blockly.Python.variableDB_.getName(block.getFieldValue('VAR'),Blockly.VARIABLE_CATEGORY_NAME);
+  return [code, Blockly.Python.ORDER_ATOMIC];
+};
+
+Blockly.Python['tkinter_variables_get_progressbar'] = function(block) {
+  Blockly.Python.definitions_['tkinter_imports'] = tkinter_imports;
+  var code = Blockly.Python.variableDB_.getName(block.getFieldValue('VAR'),Blockly.VARIABLE_CATEGORY_NAME);
+  return [code, Blockly.Python.ORDER_ATOMIC];
+};
+
 // --- BEGIN: tkinter_add_widget_to_window (Python generator)
 Blockly.Python['tkinter_add_widget_to_window'] = function(block) {
   Blockly.Python.definitions_['tkinter_imports'] = tkinter_imports;
@@ -114,6 +138,10 @@ Blockly.Python['tkinter_add_widget_to_window'] = function(block) {
   if (widgetGetter.type == 'tkinter_variables_get_label') code += `${value_widget} = tkinter.ttk.Label(${value_window})\n`;
   if (widgetGetter.type == 'tkinter_variables_get_button') code += `${value_widget} = tkinter.ttk.Button(${value_window})\n`;
   if (widgetGetter.type == 'tkinter_variables_get_entry') code += `${value_widget} = tkinter.ttk.Entry(${value_window})\n`;
+  if (widgetGetter.type == 'tkinter_variables_get_checkbutton') code += `${value_widget} = tkinter.ttk.Checkbutton(${value_window})\n`;
+  if (widgetGetter.type == 'tkinter_variables_get_radiobutton') code += `${value_widget} = tkinter.ttk.Radiobutton(${value_window})\n`;
+  if (widgetGetter.type == 'tkinter_variables_get_combobox') code += `${value_widget} = tkinter.ttk.Combobox(${value_window})\n`;
+  if (widgetGetter.type == 'tkinter_variables_get_progressbar') code += `${value_widget} = tkinter.ttk.Progressbar(${value_window})\n`;
 
   // Handle config blocks connected
   const first = block.getInputTargetBlock && block.getInputTargetBlock('DO');
@@ -207,13 +235,102 @@ Blockly.Python['tkinter_entry_delete_from_start'] = function(block) {
 
 Blockly.Python['tkinter_messagebox'] = function(block) {
   Blockly.Python.definitions_['tkinter_imports'] = tkinter_imports;
-  // messagebox is in tkinter.messagebox
   Blockly.Python.definitions_['tkinter_messagebox'] = 'import tkinter.messagebox as messagebox';
+  var title = Blockly.Python.valueToCode(block, 'TITLE', Blockly.Python.ORDER_NONE) || "'Message Box'";
   var text = Blockly.Python.valueToCode(block, 'TEXT', Blockly.Python.ORDER_NONE) || "''";
   var mode = block.getFieldValue('MODE') || 'INFO';
   var fn = 'showinfo';
   if (mode == 'WARNING') fn = 'showwarning';
   if (mode == 'ERROR') fn = 'showerror';
-  var code = 'messagebox.' + fn + '(message=' + text + ')\n';
+  var code = 'messagebox.' + fn + '(title=' + title + ', message=' + text + ')\n';
   return code;
+};
+
+Blockly.Python['tkinter_ask_dialog'] = function(block) {
+  Blockly.Python.definitions_['tkinter_imports'] = tkinter_imports;
+  Blockly.Python.definitions_['tkinter_messagebox'] = 'import tkinter.messagebox as messagebox';
+  var title = Blockly.Python.valueToCode(block, 'TITLE', Blockly.Python.ORDER_NONE) || "'Message Box'";
+  var text = Blockly.Python.valueToCode(block, 'TEXT', Blockly.Python.ORDER_NONE) || "''";
+  var mode = block.getFieldValue('MODE') || 'ASK_YES_NO';
+  var fn = 'askyesno';
+  if (mode == 'ASK_OK_CANCEL') fn = 'askokcancel';
+  if (mode == 'ASK_RETRY_CANCEL') fn = 'askretrycancel';
+  if (mode == 'ASK_YES_NO_CANCEL') fn = 'askyesnocancel';
+  if (mode == 'ASK_QUESTION') fn = 'askquestion';
+  var code = 'messagebox.' + fn + '(title=' + title + ', message=' + text + ')';
+  return [code, Blockly.Python.ORDER_FUNCTION_CALL];
+};
+
+Blockly.Python['tkinter_simpledialog'] = function(block) {
+  Blockly.Python.definitions_['tkinter_imports'] = tkinter_imports;
+  Blockly.Python.definitions_['tkinter_simpledialog'] = 'import tkinter.simpledialog as simpledialog';
+  var title = Blockly.Python.valueToCode(block, 'TITLE', Blockly.Python.ORDER_NONE) || "'Input'";
+  var prompt = Blockly.Python.valueToCode(block, 'PROMPT', Blockly.Python.ORDER_NONE) || "''";
+  var mode = block.getFieldValue('MODE') || 'STRING';
+  var fn = 'askstring';
+  if (mode == 'INTEGER') fn = 'askinteger';
+  if (mode == 'FLOAT') fn = 'askfloat';
+  var code = 'simpledialog.' + fn + '(title=' + title + ', prompt=' + prompt + ')';
+  return [code, Blockly.Python.ORDER_FUNCTION_CALL];
+};
+
+Blockly.Python['tkinter_filedialog'] = function(block) {
+  Blockly.Python.definitions_['tkinter_imports'] = tkinter_imports;
+  Blockly.Python.definitions_['tkinter_filedialog'] = 'import tkinter.filedialog as filedialog';
+  var title = Blockly.Python.valueToCode(block, 'TITLE', Blockly.Python.ORDER_NONE) || "'Select a file'";
+  var mode = block.getFieldValue('MODE') || 'OPEN';
+  var fn = 'askopenfilename';
+  if (mode == 'SAVE') fn = 'asksaveasfilename';
+  var code = 'filedialog.' + fn + '(title=' + title + ')';
+  return [code, Blockly.Python.ORDER_FUNCTION_CALL];
+};
+
+Blockly.Python['tkinter_colorchooser'] = function(block) {
+  Blockly.Python.definitions_['tkinter_imports'] = tkinter_imports;
+  Blockly.Python.definitions_['tkinter_colorchooser'] = 'import tkinter.colorchooser as colorchooser';
+  var title = Blockly.Python.valueToCode(block, 'TITLE', Blockly.Python.ORDER_NONE) || "'Choose a colour'";
+  var code = 'colorchooser.askcolor(title=' + title + ')[1]';
+  return [code, Blockly.Python.ORDER_FUNCTION_CALL];
+};
+
+Blockly.Python['tkinter_button_set_enabled'] = function(block) {
+  Blockly.Python.definitions_['tkinter_imports'] = tkinter_imports;
+  var value_button = Blockly.Python.valueToCode(block, 'BUTTON', Blockly.Python.ORDER_ATOMIC);
+  var state = block.getFieldValue('STATE') || 'ENABLED';
+  var value_state = state == 'DISABLED' ? "'disabled'" : "'normal'";
+  var code = '';
+  if (value_button == '') {
+    code = '#';
+  }
+  code = code + value_button + '.config(state=' + value_state + ')\n';
+  return code;
+};
+
+Blockly.Python['tkinter_combobox_set_values'] = function(block) {
+  Blockly.Python.definitions_['tkinter_imports'] = tkinter_imports;
+  var value_combobox = Blockly.Python.valueToCode(block, 'COMBOBOX', Blockly.Python.ORDER_MEMBER) || '[]';
+  var value_values = Blockly.Python.valueToCode(block, 'VALUES', Blockly.Python.ORDER_NONE) || '[]';
+  return value_combobox + '["values"] = ' + value_values + '\n';
+};
+
+Blockly.Python['tkinter_combobox_get_text'] = function(block) {
+  Blockly.Python.definitions_['tkinter_imports'] = tkinter_imports;
+  var value_combobox = Blockly.Python.valueToCode(block, 'COMBOBOX', Blockly.Python.ORDER_ATOMIC);
+  var code = value_combobox + '.get()';
+  return [code, Blockly.Python.ORDER_FUNCTION_CALL];
+};
+
+Blockly.Python['tkinter_progressbar_set_value'] = function(block) {
+  Blockly.Python.definitions_['tkinter_imports'] = tkinter_imports;
+  var value_progressbar = Blockly.Python.valueToCode(block, 'PROGRESSBAR', Blockly.Python.ORDER_MEMBER) || '[]';
+  var value_value = Blockly.Python.valueToCode(block, 'VALUE', Blockly.Python.ORDER_NONE) || '0';
+  return value_progressbar + '["value"] = ' + value_value + '\n';
+};
+
+Blockly.Python['tkinter_progressbar_start_stop'] = function(block) {
+  Blockly.Python.definitions_['tkinter_imports'] = tkinter_imports;
+  var value_progressbar = Blockly.Python.valueToCode(block, 'PROGRESSBAR', Blockly.Python.ORDER_MEMBER) || '[]';
+  var mode = block.getFieldValue('MODE') || 'START';
+  if (mode == 'STOP') return value_progressbar + '.stop()\n';
+  return value_progressbar + '.start()\n';
 };


### PR DESCRIPTION
### Motivation
- Remove duplicated prefill logic and make widget-prefill behaviour reusable across blocks to keep UX consistent and reduce maintenance.
- Extend GUI support with more ttk widgets and dialog options so users can build richer interfaces from the toolbox.
- Provide an enable/disable action for buttons and simple operations for Combobox/Progressbar to match other widget APIs.

### Description
- Extracted duplicated prefill logic into shared helpers `tkinterPrefillValueInputFromParent` and `tkinterOnChangePrefillFromParent` and wired `tkinter_set_widget_text` and `tkinter_set_button_command` to use them (keeps original UX but removes repetition). Files: `blocks/gui.js` (helpers + block wiring).
- Added `tkinter_button_set_enabled` block to enable/disable `ttk.Button` widgets and corresponding Python generator that emits `.config(state='normal'|'disabled')`. Files: `blocks/gui.js`, `generators/python/gui.js`.
- Expanded Dialog subcategory with richer blocks: updated `tkinter_messagebox` to accept a `TITLE` value, and added `tkinter_ask_dialog`, `tkinter_simpledialog`, `tkinter_filedialog`, and `tkinter_colorchooser` blocks; added toolbox shadows/prefilled values in `blockly_setup_end.js` to provide sensible defaults in the flyout. Files: `blocks/gui.js`, `blockly_setup_end.js`, `generators/python/gui.js`.
- Added new GUI subcategories and variable getter blocks for `Checkbutton`, `Radiobutton`, `Combobox`, and `Progressbar`, each with a “Create <widget>...” button and category callbacks; extended `tkinter_add_widget_to_window` and its Python generator to create `ttk.Checkbutton`, `ttk.Radiobutton`, `ttk.Combobox`, and `ttk.Progressbar`. Files: `blockly_setup_end.js`, `blocks/gui.js`, `generators/python/gui.js`.
- Added basic Combobox/Progressbar operation blocks and Python generators: `tkinter_combobox_set_values`, `tkinter_combobox_get_text`, `tkinter_progressbar_set_value`, and `tkinter_progressbar_start_stop`. Files: `blocks/gui.js`, `generators/python/gui.js`.
- Preserved existing coding conventions for imports and generator output (explicit `import tkinter`, `import tkinter.ttk`, plus module-scoped imports for dialog modules) and followed naming/tooltip styles consistent with existing blocks.

### Testing
- Ran JS syntax validation by evaluating modified files in Node (`blocks/gui.js`, `blockly_setup_end.js`, `generators/python/gui.js`) and all returned OK. (Succeeded.)
- Launched a local HTTP server and captured a playground toolbox screenshot via Playwright to validate the new toolbox/categories appear (artifact produced). (Succeeded.)
- Ran quick generator sanity checks by executing the updated `generators/python/gui.js` in Node to ensure no syntax errors after changes. (Succeeded.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c4c15ea68832a884fb444d051c577)